### PR TITLE
feat: add setup wizard defaults and API settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# MinutesMaster AI
+
+MinutesMaster AI is a web application for generating professional meeting minutes.
+
+## Key Features
+
+- **Setup Wizard** appears on every refresh to gather transcript and configuration details.
+- **Hamburger Sidebar** lists recent meetings and starts new sessions.
+- **API Settings** gear opens a dialog for selecting providers, models, and API keys.
+- **Dark/Light Theme** toggle and responsive three‑panel workspace layout.
+
+## Documentation
+
+- [Product Requirements](src/prd.md)
+- [CSS Design Reference](src/css-reference.md)
+
+## Development
+
+Install dependencies and run development server:
+
+```bash
+npm install
+npm run dev
+```
+
+Lint and build commands are provided but may require additional setup:
+
+```bash
+npm run lint
+npm run build
+```
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useKV } from '@github/spark/hooks'
 import { toast } from 'sonner'
 import WorkspaceLayout from '@/components/WorkspaceLayout'
 import SetupWizard from '@/components/SetupWizard'
+import type { GeneratedMinutes } from '@/types'
 
 interface DictionaryEntry {
   id: string
@@ -30,26 +31,13 @@ interface SampleMinute {
   organization?: string
 }
 
-interface GeneratedMinutes {
-  title: string
-  date: string
-  attendees: string[]
-  agenda: string[]
-  keyDecisions: string[]
-  actionItems: Array<{
-    task: string
-    assignee: string
-    dueDate: string
-  }>
-  nextSteps: string[]
-}
-
 function App() {
   const [dictionary, setDictionary] = useKV<DictionaryEntry[]>('user-dictionary', [])
   const [userInstructions, setUserInstructions] = useKV<UserInstruction[]>('user-instructions', [])
   const [sampleMinutes, setSampleMinutes] = useKV<SampleMinute[]>('sample-minutes', [])
   const [darkMode, setDarkMode] = useKV<boolean>('dark-mode', false)
-  const [hasCompletedWizard, setHasCompletedWizard] = useKV<boolean>('wizard-completed', false)
+  const [meetingHistory, setMeetingHistory] = useKV<GeneratedMinutes[]>('meeting-history', [])
+  const [hasCompletedWizard, setHasCompletedWizard] = useState(false)
   const [transcript, setTranscript] = useState('')
   const [generatedMinutes, setGeneratedMinutes] = useState<GeneratedMinutes | null>(null)
   const [isGenerating, setIsGenerating] = useState(false)
@@ -130,6 +118,10 @@ function App() {
 
       const minutes = JSON.parse(response)
       setGeneratedMinutes(minutes)
+      setMeetingHistory(prev => {
+        const history = Array.isArray(prev) ? prev : []
+        return [...history, minutes]
+      })
       setProgress(100)
 
       toast.success('Meeting minutes generated successfully!')
@@ -269,6 +261,7 @@ Jane (00:55): Good point, Sarah. Let's make that an action item. John, Sarah, pl
           onResetToWizard={resetApp}
           darkMode={darkMode}
           onToggleDarkMode={toggleDarkMode}
+          meetingHistory={meetingHistory}
         />
       )}
     </>

--- a/src/components/MinutesHistory.tsx
+++ b/src/components/MinutesHistory.tsx
@@ -1,0 +1,50 @@
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
+import { Button } from '@/components/ui/button'
+import { FileText, Menu, PlusCircle } from '@phosphor-icons/react'
+import type { GeneratedMinutes } from '@/types'
+
+interface MinutesHistoryProps {
+  meetings: GeneratedMinutes[]
+  onNewMeeting: () => void
+}
+
+export default function MinutesHistory({ meetings, onNewMeeting }: MinutesHistoryProps) {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="ghost" size="sm" className="p-2">
+          <Menu className="text-muted-foreground" />
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="left" className="w-80">
+        <SheetHeader>
+          <SheetTitle className="text-base font-semibold text-muted-foreground uppercase">
+            Recent Meetings
+          </SheetTitle>
+        </SheetHeader>
+        <div className="py-4">
+          <Button
+            onClick={onNewMeeting}
+            className="w-full bg-primary text-primary-foreground hover:bg-primary/90 px-4 py-3 rounded-md text-sm font-semibold flex items-center gap-2 mb-4"
+          >
+            <PlusCircle className="w-5 h-5" />
+            New Meeting
+          </Button>
+          <ul className="space-y-2 font-medium">
+            {meetings.length === 0 && (
+              <li className="text-sm text-muted-foreground">No meetings yet</li>
+            )}
+            {meetings.map(meeting => (
+              <li key={meeting.title}>
+                <div className="flex items-center p-2 text-foreground rounded-lg hover:bg-accent group cursor-pointer">
+                  <FileText className="mr-3" />
+                  <span>{meeting.title}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/components/WorkspaceLayout.tsx
+++ b/src/components/WorkspaceLayout.tsx
@@ -1,21 +1,11 @@
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Switch } from '@/components/ui/switch'
-import { 
-  FileText, 
-  Settings, 
-  Sparkles, 
-  Menu,
-  Sun,
-  Moon,
-  X,
-  PlusCircle
-} from '@phosphor-icons/react'
+import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog'
+import { Settings, Sparkles, Sun, Moon } from '@phosphor-icons/react'
+import MinutesHistory from './MinutesHistory'
+import ApiManager from './ApiManager'
+import type { GeneratedMinutes } from '@/types'
 
 interface DictionaryEntry {
   id: string
@@ -30,20 +20,6 @@ interface UserInstruction {
   category: string
   instruction: string
   priority: 'low' | 'medium' | 'high'
-}
-
-interface GeneratedMinutes {
-  title: string
-  date: string
-  attendees: string[]
-  agenda: string[]
-  keyDecisions: string[]
-  actionItems: Array<{
-    task: string
-    assignee: string
-    dueDate: string
-  }>
-  nextSteps: string[]
 }
 
 interface SampleMinute {
@@ -73,6 +49,7 @@ interface WorkspaceLayoutProps {
   onResetToWizard: () => void
   darkMode: boolean
   onToggleDarkMode: () => void
+  meetingHistory: GeneratedMinutes[]
 }
 
 export default function WorkspaceLayout({
@@ -90,7 +67,8 @@ export default function WorkspaceLayout({
   onExport,
   onResetToWizard,
   darkMode,
-  onToggleDarkMode
+  onToggleDarkMode,
+  meetingHistory
 }: WorkspaceLayoutProps) {
   const [activeTab, setActiveTab] = useState('dictionary')
 
@@ -131,44 +109,7 @@ export default function WorkspaceLayout({
         {/* Header */}
         <header className="header bg-card border-b border-border flex items-center justify-between px-6 py-3">
           <div className="flex items-center gap-4">
-            <Sheet>
-              <SheetTrigger asChild>
-                <Button variant="ghost" size="sm" className="p-2">
-                  <Menu className="text-muted-foreground" />
-                </Button>
-              </SheetTrigger>
-              <SheetContent side="left" className="w-80">
-                <SheetHeader>
-                  <SheetTitle className="text-base font-semibold text-muted-foreground uppercase">Recent Meetings</SheetTitle>
-                </SheetHeader>
-                <div className="py-4">
-                  <Button onClick={onResetToWizard} className="w-full bg-primary text-primary-foreground hover:bg-primary/90 px-4 py-3 rounded-md text-sm font-semibold flex items-center gap-2 mb-4">
-                    <PlusCircle className="w-5 h-5" />
-                    New Meeting
-                  </Button>
-                  <ul className="space-y-2 font-medium">
-                    <li>
-                      <a href="#" className="flex items-center p-2 text-foreground rounded-lg bg-secondary hover:bg-accent group">
-                        <FileText className="mr-3" />
-                        <span>Q3 Planning Meeting</span>
-                      </a>
-                    </li>
-                    <li>
-                      <a href="#" className="flex items-center p-2 text-foreground rounded-lg hover:bg-accent group">
-                        <FileText className="mr-3" />
-                        <span>Project Phoenix Kick-off</span>
-                      </a>
-                    </li>
-                    <li>
-                      <a href="#" className="flex items-center p-2 text-foreground rounded-lg hover:bg-accent group">
-                        <FileText className="mr-3" />
-                        <span>Marketing Weekly Sync</span>
-                      </a>
-                    </li>
-                  </ul>
-                </div>
-              </SheetContent>
-            </Sheet>
+            <MinutesHistory meetings={meetingHistory} onNewMeeting={onResetToWizard} />
             <h1 className="text-lg font-semibold">{generatedMinutes?.title || 'Q3 Planning Meeting'}</h1>
           </div>
           <div className="flex items-center gap-4">
@@ -193,39 +134,8 @@ export default function WorkspaceLayout({
                   <Settings className="text-muted-foreground" />
                 </Button>
               </DialogTrigger>
-              <DialogContent className="max-w-2xl">
-                <DialogHeader>
-                  <DialogTitle className="text-xl font-semibold">Application Settings</DialogTitle>
-                </DialogHeader>
-                <div className="space-y-4">
-                  <div>
-                    <Label htmlFor="api-key" className="block mb-2 text-sm font-medium">OpenRouter API Key</Label>
-                    <Input 
-                      type="password" 
-                      id="api-key" 
-                      defaultValue="sk-or-xxxxxxxxxx" 
-                      className="bg-secondary border border-border"
-                    />
-                  </div>
-                  <div>
-                    <Label htmlFor="cost-limit" className="block mb-2 text-sm font-medium">Monthly Cost Limit ($)</Label>
-                    <Input 
-                      type="number" 
-                      id="cost-limit" 
-                      defaultValue="20" 
-                      className="bg-secondary border border-border"
-                    />
-                  </div>
-                  <hr className="border-border"/>
-                  <div className="flex items-center space-x-2">
-                    <Switch id="auto-save" defaultChecked />
-                    <Label htmlFor="auto-save" className="text-sm font-medium">Auto-save work in progress</Label>
-                  </div>
-                </div>
-                <div className="flex items-center pt-4 border-t border-border">
-                  <Button className="bg-primary hover:bg-primary/90">Save Changes</Button>
-                  <Button variant="outline" className="ml-3">Cancel</Button>
-                </div>
+              <DialogContent className="max-w-3xl">
+                <ApiManager />
               </DialogContent>
             </Dialog>
           </div>

--- a/src/css-reference.md
+++ b/src/css-reference.md
@@ -229,6 +229,15 @@ Our shadow system creates consistent depth and hierarchy across the interface.
 }
 ```
 
+### Navigation Icons
+
+The header uses minimalist icon buttons for quick actions:
+
+- A hamburger `Menu` icon toggles the minutes history sidebar.
+- A `Settings` gear opens the API configuration dialog.
+
+Both are implemented as ghost buttons with `p-2` spacing and use `text-muted-foreground` for subtle emphasis.
+
 ## Component-Specific Styles
 
 ### Typography Components

--- a/src/prd.md
+++ b/src/prd.md
@@ -287,7 +287,7 @@ Transform meeting transcripts into professional, customized meeting minutes usin
 ### Two-Stage Application Flow
 
 #### Stage 1: Setup Wizard (New Projects)
-**Purpose**: Guide users through initial setup with progressive disclosure
+**Purpose**: Guide users through initial setup with progressive disclosure. The wizard is the default screen on every refresh, ensuring configuration steps are completed before entering the workspace.
 **Layout**: Centered modal-style interface with step navigation
 
 1. **Step 1: Transcript Upload**
@@ -329,6 +329,7 @@ Transform meeting transcripts into professional, customized meeting minutes usin
 - **Center Panel**: Generated minutes with rich text editing
 - **Right Panel**: Tabbed customization tools (Dictionary/Instructions)
 - **Header/Footer**: Project context and generation controls
+- **Header Icons**: Hamburger button opens meeting history sidebar; settings gear reveals full API configuration dialog
 
 ### Interface Transitions
 - **Smooth animations**: 300ms duration with easing for professional feel
@@ -352,6 +353,7 @@ Transform meeting transcripts into professional, customized meeting minutes usin
 - **Sample Minutes**: Template storage for style consistency
 - **API Configuration**: Encrypted storage of API keys and settings
 - **Usage Statistics**: Tracking for API usage and cost monitoring
+- **Meeting History**: Retain generated minutes metadata for quick access via the sidebar
 
 ### Performance Considerations
 - **Async Processing**: Non-blocking AI generation with progress indicators

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+export interface GeneratedMinutes {
+  title: string
+  date: string
+  attendees: string[]
+  agenda: string[]
+  keyDecisions: string[]
+  actionItems: Array<{ task: string; assignee: string; dueDate: string }>
+  nextSteps: string[]
+}


### PR DESCRIPTION
## Summary
- ensure setup wizard shows on refresh and track meeting history
- add hamburger sidebar for minutes history
- integrate advanced API configuration dialog
- document navigation controls and default wizard behavior

## Testing
- `npm run lint` (fails: ESLint couldn't find an eslint.config.js)
- `npm run build` (fails: Cannot find package '@github/spark')

------
https://chatgpt.com/codex/tasks/task_e_68924f6663848327ae9637d1ff3ebd64